### PR TITLE
productのDBにuser_idを追加

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,9 +9,12 @@ class ProductsController < ApplicationController
   end
 
   def new
-    @product= Product.new
-    @product.product_images.new
-
+    if user_signed_in?
+      @product= Product.new
+      @product.product_images.new
+    else
+      redirect_to root_path
+    end
   end
 
   def create
@@ -47,5 +50,6 @@ class ProductsController < ApplicationController
                                     :category_id,
                                     :order,
                                     product_images_attributes: [:image])
+                              .merge(user_id: current_user.id)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,7 +4,7 @@ class Product < ApplicationRecord
   has_many :product_images
   accepts_nested_attributes_for :product_images, allow_destroy: true
 
-  #belongs_to :user
+  belongs_to :user
   belongs_to :category
 
   validates :name,              presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :users
+
   validates :first_name,              presence: true
   validates :last_name,              presence: true
   validates :first_name_phonetic,              presence: true

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,10 +5,11 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   process resize_to_fit: [100, 100]
   # Choose what kind of storage to use for this uploader:
-
-  # storage :file
-
-  storage :fog
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,15 +3,19 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
- config.storage = :fog
- config.fog_provider = 'fog/aws'
- config.fog_credentials = {
-   provider: 'AWS',
-   aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-   aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-   region: 'ap-northeast-1'
- }
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  else
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: 'ap-northeast-1'
+    }
 
- config.fog_directory  = 'rails-78b'
- config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/rails-78b'
+    config.fog_directory  = 'rails-78b'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/rails-78b'
+  end
 end

--- a/db/migrate/20200707052457_add_user_to_products.rb
+++ b/db/migrate/20200707052457_add_user_to_products.rb
@@ -1,0 +1,5 @@
+class AddUserToProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :products, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_04_161733) do
+ActiveRecord::Schema.define(version: 2020_07_07_052457) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -51,7 +51,9 @@ ActiveRecord::Schema.define(version: 2020_07_04_161733) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "category_id"
+    t.bigint "user_id"
     t.index ["category_id"], name: "index_products_on_category_id"
+    t.index ["user_id"], name: "index_products_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
#What 
productのDBにuser_idを追加し、UserモデルとProductモデルでアソシエーションを組んだ。

# Why
商品出品画面の表示はログイン時のみ表示し、出品時productのDBにuser_idを追加し出品者と商品を紐づける為。