### PR TITLE
トップページに表示される商品情報の画像を１つの商品に対し１枚にする

### DIFF
--- a/app/views/products/_main.html.haml
+++ b/app/views/products/_main.html.haml
@@ -87,8 +87,7 @@
             = link_to product_path(product) ,class: "lists" do
               .Product-categoly
                 %figure.Product-categoly__product
-                  - product.product_images.each do |image|
-                    = image_tag image.image.url
+                  = image_tag product.product_images.first.image.url
                   .ProductList--body
                     .ProductList--body__name
                       = product.name


### PR DESCRIPTION
#What
トップページに表示される商品情報の画像を１つの商品に対し１枚にする。

#Why
商品に対して投稿した写真全てがトップページに表示されてしまっていたため修正しました。