### PR TITLE
【マークアップ】修正 編集　削除ボタン位置、商品詳細の編集ページでもどるを押した際に商品詳細ページにもどるようにした。

### DIFF
--- a/app/assets/stylesheets/modules/_detailview.scss
+++ b/app/assets/stylesheets/modules/_detailview.scss
@@ -133,6 +133,7 @@
   .product-details-delete__btn {
     @include btnSet; 
       background-color: red;
+      margin-top: 10px;
   }
   .product-details-edit__btn {
     @include btnSet; 
@@ -142,7 +143,6 @@
   .product-details-buy__btn {
     @include btnSet; 
       background-color: blue;
-      margin-top: 10px;
   }
 }
 

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -111,4 +111,4 @@
             = f.hidden_field :order, value: "出品中"
             = f.submit '編集する', class: 'Form__Submit'
           .Back
-            = link_to "もどる", products_path(@product.id), method: :get, class:"back-btn" 
+            = link_to "もどる", product_path(@product.id), method: :get, class:"back-btn" 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -63,8 +63,8 @@
 
   .footer
     - if user_signed_in? && current_user.id == @product.user_id
-      = link_to "削除する", product_path(@product.id), method: :delete,class:"product-details-delete__btn"
       = link_to "編集する", edit_product_path(@product.id),class:"product-details-edit__btn"
+      = link_to "削除する", product_path(@product.id), method: :delete,class:"product-details-delete__btn"
     - if user_signed_in? && current_user.id != @product.user_id
       = link_to "購入する", buy_product_path, method: :get,class:"product-details-buy__btn" 
     


### PR DESCRIPTION
#why
 編集ボタンが上の方が良いという声が挙がったため。
もどるを押した際にひとつ前の詳細ページではなく、トップページに戻っていたため。

#what
 編集ボタンを上にした。
 もどるを正常に動くようにした。
