### PR TITLE
商品詳細ページのカテゴリ表示バグ修正

### DIFF
--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -33,7 +33,7 @@
                       %label{for: "product_product_images_attributes_#{@product.product_images.length}_image", class: "label-box", id: "label-box--#{@product.product_images.length}"}
                         %pre.label-box__text-visible クリックしてファイルをアップロード
                     - else
-                      %label{for: "pproduct_roduct_images_attributes_#{@product.product_images.length}_image", class: "label-box label_box--hide", id: "label-box--#{@product.product_images.length}"}
+                      %label{for: "product_product_images_attributes_#{@product.product_images.length}_image", class: "label-box label_box--hide", id: "label-box--#{@product.product_images.length}"}
                         %pre.label-box__text-visible クリックしてファイルをアップロード
 
                   .hidden-content

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -35,8 +35,7 @@
                     =@product.user.nickname
                 %tr
                   %th カテゴリー
-                  %td 
-                    =@product.category.name
+                  %td
                     - @parents.each do |parent|
                       -if @product.category_id == parent.id
                         = parent.name


### PR DESCRIPTION
# What
商品詳細ページのカテゴリ表示が二重に表示されていたバグを修正した。

# Why
商品詳細ページのカテゴリ表示が二重に表示されていると、ユーザーに混乱を招く為。